### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://kunal.visualstudio.com/30be2058-e068-483e-a194-825b65049101/0ab87ccb-e959-4406-afe5-0da97ee740c0/_apis/work/boardbadge/39ee39ec-dad6-4688-9cce-54e40f3190ef)](https://kunal.visualstudio.com/30be2058-e068-483e-a194-825b65049101/_boards/board/t/0ab87ccb-e959-4406-afe5-0da97ee740c0/Microsoft.RequirementCategory)
 [![Build Status](https://kunal.visualstudio.com/SimpleConsoleLogger/_apis/build/status/kunalranglani.SimpleConsoleLogger?branchName=master)](https://kunal.visualstudio.com/SimpleConsoleLogger/_build/latest?definitionId=3&branchName=master)
 
 # SimpleConsoleLogger


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#37](https://kunal.visualstudio.com/30be2058-e068-483e-a194-825b65049101/_workitems/edit/37). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.